### PR TITLE
Add user settings for folding any file. Fold on file save

### DIFF
--- a/Base64 Fold.sublime-settings
+++ b/Base64 Fold.sublime-settings
@@ -1,0 +1,19 @@
+{
+	// This settings file will be rewrote on package updates. User settings
+	// should be placed in Packages/User/Preferences.sublime-settings, which
+	// can be openned from menu "Preferences > Settings - User"
+
+	// Fold Base64 code in any file when this is set to true
+	"base64fold_any_file": false,
+
+	// When "base64fold_any_file" is set to false, or is omitted, fold Base64
+	// code in files that match one of the file extensions listed here.
+	// If this list is set to empty (like this: []) while "base64fold_any_file"
+	// not being true, no Base64 code will be folded.
+	// Note: File extension should NOT begin with "." i.e. "css" not ".css"
+	"base64fold_file_extensions":
+	[
+		"css","less","sass","scss",
+		"htm","html"
+	]
+}

--- a/Base64Fold.py
+++ b/Base64Fold.py
@@ -3,17 +3,45 @@ import sublime, sublime_plugin
 
 class FoldBase64Command(sublime_plugin.TextCommand):
   def run(self, edit):
-    regions = self.view.find_all('(?<=base64\,)[\w\d\+\/=]+(?=[\'\"]?\);?)')
+    # Base64 decodes each 4 encoded characters into 3 octects. The padding '='
+    # character might appear 1 or 2 times only at the end of the Base64 code,
+    # and only if there are less than 3 octects to be decoded. We don't need to
+    # match what (["');], etc) is behind the code, as we are not folding them.
+    regions = self.view.find_all('(?<=base64\,)[\w\d\+\/]{2,}={0,2}')
     if regions:
-      self.view.fold(regions)
+      # Only fold Base64 code that has a valid length
+      self.view.fold([r for r in regions if r.size() % 4 == 0])
 
 class Base64Fold(sublime_plugin.EventListener):
   def on_load(self, view):
-    style_files_exts = ['.css', '.less', '.sass', '.scss']
+    prepare_fold(view)
+
+  def on_pre_save(self, view):
+    prepare_fold(view)
+
+def prepare_fold(view):
+  fold_any_file = False
+  fold_file_extensions = []
+  scope_package = "package"
+  scope_sublime = "sublime"
+  settings = {
+    scope_package: sublime.load_settings("Base64 Fold.sublime-settings"),
+    scope_sublime: view.settings()
+  }
+  # Settings override order:
+  #   User/Preferences > User/Base64 Fold > Base64 Fold/Base64 Fold
+  for scope in [scope_package, scope_sublime]:
+    if settings[scope]:
+      fold_any_file = settings[scope].get("base64fold_any_file", fold_any_file)
+      fold_file_extensions = settings[scope].get("base64fold_file_extensions",
+        fold_file_extensions)
+  if fold_any_file:
+    view.run_command('fold_base64')
+  elif len(fold_file_extensions) > 0:
     file_name = view.file_name()
     if file_name:
-      match = re.search('\.[0-9a-z]+$', file_name, re.IGNORECASE)
+      match = re.search('(?<=\.)[0-9a-z]+$', file_name, re.IGNORECASE)
       if match:
         extension = match.group(0)
-        if extension in style_files_exts:
+        if extension in fold_file_extensions:
           view.run_command('fold_base64')

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Don't forget about these default Sublime key shortcuts:
 Fold:   ```ctrl+shift+]```
 
 Unfold: ```ctrl+shift+[```
+
+Settings
+--------
+
+By defaults, only Base64 code in CSS and HTML files (recognized by file extensions) will be folded. You can set it to fold in any file, or limit to specific file extensions, by adding your settings to user preferences file, which can be openned from menu `Preferences > Settings - User`.
+
+For details, see `Packages/Base64 Fold/Base64 Fold.sublime-settings`, or the latest version [here](Base64 Fold.sublime-settings).


### PR DESCRIPTION
Two settings are added, namly "base64fold_any_file" and
"base64fold_file_extensions", which can be set in the usual place
(Packages/User/Preferences.sublime-settings). See the descriptions in
the settings file for details.

To allow folding in any files, some adjustments are made to the regular
expression. Also, if the Base64 code length was not valid (not being a
multiple of 4), it won't be folded.

.htm and .html are added to the default file extensions list.

Another new feature is that Base64 code will be folded while the file is
being saved, not just after the file is openned.
